### PR TITLE
Added missing lines to factorizer

### DIFF
--- a/factorizer.cpp
+++ b/factorizer.cpp
@@ -1,6 +1,8 @@
 #include <bits/stdc++.h>
 using namespace std;
 
+#define mk make_pair
+
 using i32 = int32_t;
 using i64 = int64_t;
 using i128 = __int128_t;

--- a/factorizer.cpp
+++ b/factorizer.cpp
@@ -1,7 +1,7 @@
 #include <bits/stdc++.h>
 using namespace std;
 
-#define mk make_pair
+#define mp make_pair
 
 using i32 = int32_t;
 using i64 = int64_t;
@@ -158,8 +158,8 @@ template <typename T>
 vector<pair<T, int>> RhoC(T n, T c) {
     if (n <= 1) return {};
     if (!(n & 1))
-        return MergeFactors({mk(static_cast<T>(2), 1)}, RhoC(n >> 1, c));
-    if (IsPrime(n)) return {mk(n, 1)};
+        return MergeFactors({mp(static_cast<T>(2), 1)}, RhoC(n >> 1, c));
+    if (IsPrime(n)) return {mp(n, 1)};
     T g = brent(n, static_cast<T>(2), c);
     return MergeFactors(RhoC(g, c + 1), RhoC(n / g, c + 1));
 }


### PR DESCRIPTION
Current factorizer.cpp file was not compiling due to missing declaration for 'mk' keyword . Fixed by adding the following code snippet:
```
#define mk make_pair
```

Additionally did some benchmark testing on [Yosupo](https://judge.yosupo.jp/submission/220002) , code takes 168 ms to factorize 100 integers upto 1e18 in worst case. 